### PR TITLE
Set local foldmethod to manual

### DIFF
--- a/autoload/disassemble.vim
+++ b/autoload/disassemble.vim
@@ -82,6 +82,7 @@ func disassemble#Disassemble(cmdmods, arg)
   setlocal nomodified nomodifiable filetype=asm buftype=nofile bufhidden=wipe
 
   " create folds
+  setlocal foldmethod=manual
   setlocal foldenable foldcolumn=1
   g/^\x\+ /.+1,/^$/fold
   normal zR


### PR DESCRIPTION
If the foldmethod=syntax, an error is thrown that the fold is not possible with the current method.